### PR TITLE
Fix < > \ in da_DK.lang

### DIFF
--- a/locales/da_DK.lang
+++ b/locales/da_DK.lang
@@ -1,7 +1,4 @@
 /*
- * < > bslash
- * NOTE: The above characters don't work as i do not know which code is required. This is due to the fact that the danish keyboard has these characters mapped to a key between Z and left shift, which doesn't exist on american keyboards. If you know hot to fix this problem you are welcome to make a pull request and fix it.
- *
  * Due to how the danish keyboard works some characters (~, ^, `)  have to be pressed twice, on ubuntu two presses creates one character, on windows one press creates no charater and two presses creates two.
  *
  * This means that the required test string is "!\"#$%&'()*+,-./0123456789:;<=>?ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^^``_abcdefghijklmnopqrstuvwxyz{|}~~ @"
@@ -72,9 +69,9 @@ const uint8_t _asciimap[128] =
   0x26,          // 9
   0x37|SHIFT,    // :
   0x36|SHIFT,    // ;
-  0x56,          // <--
+  0x64,          // <
   0x27|SHIFT,      // =
-  0x56|SHIFT,      // >--
+  0x64|SHIFT,      // >
   0x2d|SHIFT,      // ?
   0x1f,            // @
   0x04|SHIFT,      // A
@@ -104,7 +101,7 @@ const uint8_t _asciimap[128] =
   0x1c|SHIFT,      // Y
   0x1d|SHIFT,      // Z
   0x25,          // [
-  0x2d,          // bslash--
+  0x64,          // bslash
   0x26,          // ]
   0x30|SHIFT,    // ^
   0x38|SHIFT,    // _


### PR DESCRIPTION
I fixed these characters. All ASCII Characters work now
This fixes #21

I used this method
`sudo cat /dev/hidraw0 > scancode`
press the disered key, press Ctrl + C to stop
`hexdump scancode`